### PR TITLE
Respect the PASSWORD_STORE_DIR environment variable of pass itself

### DIFF
--- a/zsh-fzf-pass.zsh
+++ b/zsh-fzf-pass.zsh
@@ -1,6 +1,6 @@
 function fuzzy-pass() {
   DIR=$(pwd)
-  cd "${HOME}/.password-store"
+  cd "${PASSWORD_STORE_DIR:-${HOME}/.password-store}"
   PASSFILE=$(tree -Ffi | grep '.gpg' | sed 's/.gpg$//g' | sed 's/^..//' | fzf)
 
   [ -z "$PASSFILE" ] && return 0


### PR DESCRIPTION
This change will prefer the PASSWORD_STORE_DIR variable if it is set, otherwise it will default to `$HOME/.password-store`