### PR TITLE
Symlink follow and no forced directory swap

### DIFF
--- a/zsh-fzf-pass.zsh
+++ b/zsh-fzf-pass.zsh
@@ -1,7 +1,7 @@
 function fuzzy-pass() {
   DIR=$(pwd)
   cd "${PASSWORD_STORE_DIR:-${HOME}/.password-store}"
-  PASSFILE=$(tree -Ffi | grep '.gpg' | sed 's/.gpg$//g' | sed 's/^..//' | fzf)
+  PASSFILE=$(find -L . | grep '.gpg' | sed 's/.gpg$//g' | sed 's/^..//' | fzf)
 
   [ -z "$PASSFILE" ] && return 0
 

--- a/zsh-fzf-pass.zsh
+++ b/zsh-fzf-pass.zsh
@@ -1,7 +1,6 @@
 function fuzzy-pass() {
-  DIR=$(pwd)
-  cd "${PASSWORD_STORE_DIR:-${HOME}/.password-store}"
-  PASSFILE=$(find -L . | grep '.gpg' | sed 's/.gpg$//g' | sed 's/^..//' | fzf)
+  PASS_STR_VALID_DIR="${PASSWORD_STORE_DIR:-${HOME}/.password-store}"
+  PASSFILE=$(find -L $PASS_STR_VALID_DIR | sed "s|$PASS_STR_VALID_DIR||" | grep '.gpg' | sed 's/.gpg$//g' | fzf)
 
   [ -z "$PASSFILE" ] && return 0
 
@@ -17,8 +16,6 @@ function fuzzy-pass() {
     URL="$(basename $(dirname "${PASSFILE}"))"
     URL="$(echo "${URL}" | grep "\.")"
   fi
-
-  cd ${DIR}
 
   ACTIONS="Edit\nFile"
 


### PR DESCRIPTION
Hi. As I was not able to force `tree` to handle symlinked directories into password-store i rewrote it to use `find`.
This is another bonus cause `find` is also more commonly installed package (beside my love for tree).
Also I removed all directory swap related code as keyboardInterrupt before correct exit simply leave us in password store directory and that is unwanted behaviour.